### PR TITLE
[TASK] Allow field `tsconfig_includes`

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -7,5 +7,4 @@ defined('TYPO3_MODE') or die();
     mod.web_ts.menu.function.tx_tstemplateceditor = 0
     mod.web_ts.menu.function.tx_tstemplateinfo = 0
     TCEFORM.pages.TSconfig.disabled=1
-    TCEFORM.pages.tsconfig_includes.disabled=1
 ');


### PR DESCRIPTION
The field `tsconfig_includes` should not be removed as it can be used to change parts of the tree. as this field needs to be filled by an extension (which is under version control) it doesn't contain any magic inline code