### PR TITLE
[TASK] Switch from constant TYPO3_MODE to TYPO3

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 // Register autoloading for TypoScript
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Core/TypoScript/TemplateService']['runThroughTemplatesPostProcessing']['bolt'] = \B13\Bolt\TypoScript\Loader::class . '->addSiteConfiguration';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 // disable sys_templates - could be done as an option of the extension dynamically
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('


### PR DESCRIPTION
Constant TYPO3 has been released with 10.4.11
already, we should be able to switch to it
since TYPO3 v12 no longer sets it.