### PR TITLE
[TASK] Add TYPO3 v12 compatible TypoScript event

### DIFF
--- a/Classes/Configuration/PackageHelper.php
+++ b/Classes/Configuration/PackageHelper.php
@@ -16,6 +16,8 @@ use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Package\Exception\UnknownPackageException;
 use TYPO3\CMS\Core\Package\PackageInterface;
 use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteInterface;
 use TYPO3\CMS\Core\Site\SiteFinder;
 
 /**
@@ -54,6 +56,20 @@ class PackageHelper
         } catch (SiteNotFoundException $e) {
             return null;
         } catch (UnknownPackageException $e) {
+            return null;
+        }
+    }
+
+    public function getSitePackageFromSite(Site $site): ?PackageInterface
+    {
+        $configuration = $site->getConfiguration();
+        if (!isset($configuration['sitePackage'])) {
+            return null;
+        }
+        $packageKey = (string)$configuration['sitePackage'];
+        try {
+            return $this->packageManager->getPackage($packageKey);
+        } catch (UnknownPackageException $_) {
             return null;
         }
     }

--- a/Classes/TypoScript/AddTypoScriptFromSiteExtensionEvent.php
+++ b/Classes/TypoScript/AddTypoScriptFromSiteExtensionEvent.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "bolt" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\Bolt\TypoScript;
+
+use B13\Bolt\Configuration\PackageHelper;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\TypoScript\IncludeTree\Event\AfterTemplatesHaveBeenDeterminedEvent;
+
+/**
+ * Event listener in FE and BE (ext:tstemplate) to add a typoscript template "fake" sys_template
+ * row that auto-adds TypoScript when the site has a 'sitePackage' set and has a
+ * "Configuration/TypoScript/constants.typoscript" or "Configuration/TypoScript/setup.typoscript" file.
+ *
+ * Works with TYPO3 >= v12
+ */
+final class AddTypoScriptFromSiteExtensionEvent
+{
+    protected PackageHelper $packageHelper;
+
+    public function __construct(PackageHelper $packageHelper)
+    {
+        $this->packageHelper = $packageHelper;
+    }
+
+    public function __invoke(AfterTemplatesHaveBeenDeterminedEvent $event): void
+    {
+        $site = $event->getSite();
+        if (!$site instanceof Site) {
+            return;
+        }
+        $package = $this->packageHelper->getSitePackageFromSite($site);
+        if ($package === null) {
+            return;
+        }
+
+        $constantsFile = $package->getPackagePath() . 'Configuration/TypoScript/constants.typoscript';
+        $setupFile = $package->getPackagePath() . 'Configuration/TypoScript/setup.typoscript';
+        if (!file_exists($constantsFile)) {
+            $constantsFile = $package->getPackagePath() . 'Configuration/TypoScript/constants.txt';
+        }
+        if (!file_exists($setupFile)) {
+            $setupFile = $package->getPackagePath() . 'Configuration/TypoScript/setup.txt';
+        }
+
+        $constants = null;
+        if (file_exists($constantsFile)) {
+            $constants = (string)@file_get_contents($constantsFile);
+        }
+        $setup = null;
+        if (file_exists($setupFile)) {
+            $setup = (string)@file_get_contents($setupFile);
+        }
+
+        if (empty($constants) && empty($setup)) {
+            return;
+        }
+
+        $siteRootPageId = $site->getRootPageId();
+        $rootline = $event->getRootline();
+        $sysTemplateRows = $event->getTemplateRows();
+
+        $highestUid = 1;
+        foreach ($sysTemplateRows as $sysTemplateRow) {
+            if ((int)($sysTemplateRow['uid'] ?? 0) > $highestUid) {
+                $highestUid = (int)$sysTemplateRow['uid'];
+            }
+        }
+
+        $fakeRow = [
+            'uid' => $highestUid + 1,
+            'pid' => $siteRootPageId,
+            'title' => 'Site extension include EXT:' . $package->getPackageKey() . ' by EXT:bolt',
+            'root' => 1,
+            'clear' => 3,
+            'include_static_file' => null,
+            'constants' => (string)$constants,
+            'config' => (string)$setup,
+            // Add a flag. This might be useful for other event listeners that may want to manipulate again.
+            'isExtBoltFakeRow' => true,
+        ];
+        // Set various "db" fields conditionally to be as robust as possible in case
+        // core or some other loaded extension fiddles with them.
+        $deleteField = $GLOBALS['TCA']['sys_template']['ctrl']['delete'] ?? null;
+        if ($deleteField) {
+            $fakeRow[$deleteField] = 0;
+        }
+        $disableField = $GLOBALS['TCA']['sys_template']['ctrl']['enablecolumns']['disabled'] ?? null;
+        if ($disableField) {
+            $fakeRow[$disableField] = 0;
+        }
+        $endtimeField = $GLOBALS['TCA']['sys_template']['ctrl']['enablecolumns']['endtime'] ?? null;
+        if ($endtimeField) {
+            $fakeRow[$endtimeField] = 0;
+        }
+        $starttimeField = $GLOBALS['TCA']['sys_template']['ctrl']['enablecolumns']['starttime'] ?? null;
+        if ($starttimeField) {
+            $fakeRow[$starttimeField] = 0;
+        }
+        $sortbyField = $GLOBALS['TCA']['sys_template']['ctrl']['sortby'] ?? null;
+        if ($sortbyField) {
+            $fakeRow[$sortbyField] = 0;
+        }
+        $tstampField = $GLOBALS['TCA']['sys_template']['ctrl']['tstamp'] ?? null;
+        if ($tstampField) {
+            $fakeRow[$tstampField] = ($setup ? filemtime($setupFile) : null) ?? ($constants ? filemtime($constantsFile) : null) ?? time();
+        }
+        if ($GLOBALS['TCA']['sys_template']['columns']['basedOn'] ?? false) {
+            $fakeRow['basedOn'] = null;
+        }
+        if ($GLOBALS['TCA']['sys_template']['columns']['includeStaticAfterBasedOn'] ?? false) {
+            $fakeRow['includeStaticAfterBasedOn'] = 0;
+        }
+        if ($GLOBALS['TCA']['sys_template']['columns']['static_file_mode'] ?? false) {
+            $fakeRow['static_file_mode'] = 0;
+        }
+
+        if (empty($sysTemplateRows)) {
+            // Simple things first: If there are no sys_template records yet, add our fake row and done.
+            $sysTemplateRows[] = $fakeRow;
+            $event->setTemplateRows($sysTemplateRows);
+            return;
+        }
+
+        // When there are existing sys_template rows, we try to add our fake row at the most useful position.
+        $newSysTemplateRows = [];
+        $pidsBeforeSite = [0];
+        $reversedRootline = array_reverse($rootline);
+        foreach ($reversedRootline as $page) {
+            if (($page['uid'] ?? 0) !== $siteRootPageId) {
+                $pidsBeforeSite[] = (int)($page['uid'] ?? 0);
+            } else {
+                break;
+            }
+        }
+        $pidsBeforeSite = array_unique($pidsBeforeSite);
+
+        $fakeRowAdded = false;
+        foreach ($sysTemplateRows as $sysTemplateRow) {
+            if ($fakeRowAdded) {
+                // We added the fake row already. Just add all other templates below this.
+                $newSysTemplateRows[] = $sysTemplateRow;
+                continue;
+            }
+            if (in_array((int)($sysTemplateRow['pid'] ?? 0), $pidsBeforeSite)) {
+                $newSysTemplateRows[] = $sysTemplateRow;
+                // If there is a sys_template row *before* our site, we assume settings from above
+                // templates should "fall through", so we unset the clear flags. If this is not
+                // wanted, an instance may need to register another event listener after this one
+                // to set the clear flag again.
+                $fakeRow['clear'] = 0;
+            } elseif ((int)($sysTemplateRow['pid'] ?? 0) === $siteRootPageId) {
+                // There is a sys_template on the site root page already. We add our fake row before
+                // this one, then force the root and the clear flag of the sys_template row to 0.
+                $newSysTemplateRows[] = $fakeRow;
+                $fakeRowAdded = true;
+                $sysTemplateRow['root'] = 0;
+                $sysTemplateRow['clear'] = 0;
+                $newSysTemplateRows[] = $sysTemplateRow;
+            } else {
+                // Not a sys_template row before, not an sys_template record on same page. Add our
+                // fake row and mark we added it.
+                $newSysTemplateRows[] = $fakeRow;
+                $fakeRowAdded = true;
+            }
+        }
+        $event->setTemplateRows($newSysTemplateRows);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,3 +16,11 @@ services:
 
   B13\Bolt\TypoScript\Loader:
     public: true
+
+  B13\Bolt\TypoScript\AddTypoScriptFromSiteExtensionEvent:
+    public: true
+    tags:
+      - name: event.listener
+        identifier: 'b13-bolt/add-typoscript-from-site-extension'
+        # for v10 compat, optional since v11
+        event: TYPO3\CMS\Core\TypoScript\IncludeTree\Event\AfterTemplatesHaveBeenDeterminedEvent

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,5 +1,0 @@
-@isroot
-@clear
-@sitetitle "My site title only in constants available"
-@import "EXT:gridelements/TypoScript/*.txt"
-@import "myexample/site_base/Configuration/TypoScript/setup.txt"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,5 +2,5 @@
 
 defined('TYPO3') or die();
 
-// Register autoloading for TypoScript
+// Register autoloading for TypoScript for TYPO3 v10 and v11
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Core/TypoScript/TemplateService']['runThroughTemplatesPostProcessing']['bolt'] = \B13\Bolt\TypoScript\Loader::class . '->addSiteConfiguration';


### PR DESCRIPTION
Hook 'runThroughTemplatesPostProcessing' has been deprecated with TYPO3 v12. Use event AfterTemplatesHaveBeenDeterminedEvent to add the TypoScript from site extension.