### PR TITLE
[FEATURE] Make sitePackage editable in Backend Sites module

### DIFF
--- a/Classes/Configuration/PackageHelper.php
+++ b/Classes/Configuration/PackageHelper.php
@@ -26,7 +26,6 @@ use TYPO3\CMS\Core\Site\SiteFinder;
  */
 class PackageHelper
 {
-
     /**
      * @var PackageManager
      */
@@ -71,6 +70,38 @@ class PackageHelper
             return $this->packageManager->getPackage($packageKey);
         } catch (UnknownPackageException $_) {
             return null;
+        }
+    }
+
+    /**
+     * "itemsProcFunc" method adding a list of available "site_*" extension
+     * keys as select drop down items. Used in Site backend module.
+     */
+    public function getSiteListForSiteModule(array &$fieldDefinition): void
+    {
+        $fieldDefinition['items'][] = [
+            '-- None --',
+            ''
+        ];
+        $currentValue = $fieldDefinition['row']['sitePackage'] ?? '';
+        $gotCurrentValue = false;
+        foreach ($this->packageManager->getActivePackages() as $package) {
+            $packageKey = $package->getPackageKey();
+            if (substr($packageKey, 0, 5 ) === 'site_') {
+                $fieldDefinition['items'][] = [
+                    0 => $packageKey,
+                    1 => $packageKey,
+                ];
+                if ($currentValue === $packageKey) {
+                    $gotCurrentValue = true;
+                }
+            }
+        }
+        if (!$gotCurrentValue && $currentValue !== '') {
+            $fieldDefinition['items'][] = [
+                0 => $currentValue,
+                1 => $currentValue,
+            ];
         }
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,6 +7,9 @@ services:
   B13\Bolt\:
     resource: '../Classes/*'
 
+  B13\Bolt\Configuration\PackageHelper:
+    public: true
+
   B13\Bolt\TsConfig\Loader:
     public: true
     tags:

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of TYPO3 CMS-based extension "bolt" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+$GLOBALS['SiteConfiguration']['site']['columns']['sitePackage'] = [
+    'label' => 'Site package of this site',
+    'description' => '[EXT:bolt] Attached site extension with TypoScript and TsConfig entry points',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'itemsProcFunc' => \B13\Bolt\Configuration\PackageHelper::class . '->getSiteListForSiteModule',
+    ],
+];
+$GLOBALS['SiteConfiguration']['site']['palettes']['default']['showitem'] .= ',
+    sitePackage,
+';


### PR DESCRIPTION
Add 'fake TCA' config adding the 'sitePackage'
field to the Backend Sites module when editing a
site config to select the attached site
package / extension.

The field is a select drop down that shows all
extensions that start with "site_".

The field can of course still be manually set in
the .yaml file and is not overridden when editing
the site config.