### PR TITLE
[TASK] Prepare for TYPO3 v13 PageTsConfig event

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,9 +13,16 @@ services:
   B13\Bolt\TsConfig\Loader:
     public: true
     tags:
+      # Remove when TYPO3 v11 compat is dropped
+      - name: event.listener
+        identifier: 'add-site-configuration-v11'
+        event: TYPO3\CMS\Core\Configuration\Event\ModifyLoadedPageTsConfigEvent
+        method: 'addSiteConfigurationCore11'
+      # TYPO3 v12 and above
       - name: event.listener
         identifier: 'add-site-configuration'
-        event: TYPO3\CMS\Core\Configuration\Event\ModifyLoadedPageTsConfigEvent
+        event: TYPO3\CMS\Core\TypoScript\IncludeTree\Event\ModifyLoadedPageTsConfigEvent
+        method: 'addSiteConfiguration'
 
   B13\Bolt\TypoScript\Loader:
     public: true


### PR DESCRIPTION
TYPO3 v12 deprecated the ModifyLoadedPageTsConfigEvent with https://review.typo3.org/c/Packages/TYPO3.CMS/+/76565 and moved to a similar event in a different namespace.

The patch starts listening for the new event and suppresses handling the old event in TYPO3 v12 to not do things twice.

This prepares for TYPO3 v13 so code can be easily removed when extension compatibility TYPO3 v11 is dropped later.