### PR TITLE
FEATURE: Allow for configurable site package prefix

### DIFF
--- a/Classes/Configuration/PackageHelper.php
+++ b/Classes/Configuration/PackageHelper.php
@@ -36,16 +36,10 @@ class PackageHelper
      */
     protected $siteFinder;
 
-    /**
-     * @var ExtensionConfiguration
-     */
-    protected $extensionConfiguration;
-
-    public function __construct(PackageManager $packageManager, SiteFinder $siteFinder, ExtensionConfiguration $extensionConfiguration)
+    public function __construct(PackageManager $packageManager, SiteFinder $siteFinder)
     {
         $this->packageManager = $packageManager;
         $this->siteFinder = $siteFinder;
-        $this->extensionConfiguration = $extensionConfiguration;
     }
 
     public function getSitePackage(int $rootPageId): ?PackageInterface
@@ -79,7 +73,6 @@ class PackageHelper
      */
     public function getSiteListForSiteModule(array &$fieldDefinition): void
     {
-        $sitePackagePrefix = $this->extensionConfiguration->get('bolt', 'sitePackagePrefix');
         $fieldDefinition['items'][] = [
             '-- None --',
             '',
@@ -87,8 +80,8 @@ class PackageHelper
         $currentValue = $fieldDefinition['row']['sitePackage'] ?? '';
         $gotCurrentValue = false;
         foreach ($this->packageManager->getActivePackages() as $package) {
-            $packageKey = $package->getPackageKey();
-            if (substr($packageKey, 0, strlen($sitePackagePrefix)) === $sitePackagePrefix) {
+            if ($package->getPackageMetaData()->getPackageType() === 'typo3-cms-site') {
+                $packageKey = $package->getPackageKey();
                 $fieldDefinition['items'][] = [
                     0 => $packageKey,
                     1 => $packageKey,

--- a/Classes/Configuration/PackageHelper.php
+++ b/Classes/Configuration/PackageHelper.php
@@ -12,6 +12,7 @@ namespace B13\Bolt\Configuration;
  * of the License, or any later version.
  */
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Package\Exception\UnknownPackageException;
 use TYPO3\CMS\Core\Package\PackageInterface;
@@ -35,10 +36,16 @@ class PackageHelper
      */
     protected $siteFinder;
 
-    public function __construct(PackageManager $packageManager, SiteFinder $siteFinder)
+    /**
+     * @var ExtensionConfiguration
+     */
+    protected $extensionConfiguration;
+
+    public function __construct(PackageManager $packageManager, SiteFinder $siteFinder, ExtensionConfiguration $extensionConfiguration)
     {
         $this->packageManager = $packageManager;
         $this->siteFinder = $siteFinder;
+        $this->extensionConfiguration = $extensionConfiguration;
     }
 
     public function getSitePackage(int $rootPageId): ?PackageInterface
@@ -72,6 +79,7 @@ class PackageHelper
      */
     public function getSiteListForSiteModule(array &$fieldDefinition): void
     {
+        $sitePackagePrefix = $this->extensionConfiguration->get('bolt', 'sitePackagePrefix');
         $fieldDefinition['items'][] = [
             '-- None --',
             '',
@@ -80,7 +88,7 @@ class PackageHelper
         $gotCurrentValue = false;
         foreach ($this->packageManager->getActivePackages() as $package) {
             $packageKey = $package->getPackageKey();
-            if (substr($packageKey, 0, 5) === 'site_') {
+            if (substr($packageKey, 0, strlen($sitePackagePrefix)) === $sitePackagePrefix) {
                 $fieldDefinition['items'][] = [
                     0 => $packageKey,
                     1 => $packageKey,

--- a/Resources/Private/Language/ext_conf_template.xlf
+++ b/Resources/Private/Language/ext_conf_template.xlf
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:bolt/Resources/Private/Language/ext_conf_template.xlf"  product-name="bolt">
+		<body>
+			<trans-unit id="sitePackagePrefix.label" resname="sitePackagePrefix.label">
+				<source>Site package prefix</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=General; type=string; label=LLL:EXT:bolt/Resources/Private/Language/ext_conf_template.xlf:sitePackagePrefix.label
+sitePackagePrefix = site_


### PR DESCRIPTION
The newly introduced extension configuration allows to change the site package prefix.

By default it's value is site_. Changing this, will only have effect for displayed items in the list of site configuration module.

Resolves: #43