### PR TITLE
[TASK] Add option to include TypoScript from custom path

### DIFF
--- a/Classes/TypoScript/AddTypoScriptFromSiteExtensionEvent.php
+++ b/Classes/TypoScript/AddTypoScriptFromSiteExtensionEvent.php
@@ -43,13 +43,18 @@ final class AddTypoScriptFromSiteExtensionEvent
             return;
         }
 
-        $constantsFile = $package->getPackagePath() . 'Configuration/TypoScript/constants.typoscript';
-        $setupFile = $package->getPackagePath() . 'Configuration/TypoScript/setup.typoscript';
+        $typoScriptPath = $package->getPackagePath() . 'Configuration/TypoScript/';
+        if ($site->getConfiguration()['typoScriptTemplatePath'] ?? false) {
+            $typoScriptPath = $package->getPackagePath() . rtrim($site->getConfiguration()['typoScriptTemplatePath'], '/') . '/';
+        }
+
+        $constantsFile = $typoScriptPath . 'constants.typoscript';
+        $setupFile = $typoScriptPath . 'setup.typoscript';
         if (!file_exists($constantsFile)) {
-            $constantsFile = $package->getPackagePath() . 'Configuration/TypoScript/constants.txt';
+            $constantsFile = $typoScriptPath . 'constants.txt';
         }
         if (!file_exists($setupFile)) {
-            $setupFile = $package->getPackagePath() . 'Configuration/TypoScript/setup.txt';
+            $setupFile = $typoScriptPath . 'setup.txt';
         }
 
         $constants = null;

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -17,6 +17,16 @@ $GLOBALS['SiteConfiguration']['site']['columns']['sitePackage'] = [
         'itemsProcFunc' => \B13\Bolt\Configuration\PackageHelper::class . '->getSiteListForSiteModule',
     ],
 ];
+
+$GLOBALS['SiteConfiguration']['site']['columns']['typoScriptTemplatePath'] = [
+    'label' => 'Custom path to the TypoScript template',
+    'description' => '[EXT:bolt] Defined a custom path to the TypoScript template to be included instead of the default "Configuration/TypoScript/".',
+    'config' => [
+        'type' => 'input',
+    ],
+];
+
 $GLOBALS['SiteConfiguration']['site']['palettes']['default']['showitem'] .= ',
     sitePackage,
+    typoScriptTemplatePath,
 ';

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ extension manager.
   the site extension the single entry point of your Site configuration that provides all site specific
   settings!
 
+* Optional (v12 and up): Use `typoScriptTemplatePath` to include TypoScript from a custom defined path.
+  Useful if there are plenty of sites that should be server using a single extension.
 
 ## Disabled Backend settings
 


### PR DESCRIPTION
Currently, it is not possible to use a custom template path. This can be useful if you have plenty of sites which do not use a dedicated extension for each site.

This change adds the site setting "typoScriptTemplatePath" which allows to define a custom path for the TypoScript templates to be included.